### PR TITLE
Require Resolv library to pass specs

### DIFF
--- a/lib/warden/ldap/connection.rb
+++ b/lib/warden/ldap/connection.rb
@@ -1,5 +1,5 @@
 require 'yaml'
-
+require 'resolv'
 module Warden
   module Ldap
     class Connection


### PR DESCRIPTION
**[Resolv](http://www.rubydoc.info/stdlib/resolv/Resolv)** is a Ruby standard library.

This PR fixes the failing test suite, by requiring Resolv.
