### PR TITLE
RSpec: avoid warning about default value

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,6 @@ end
 require File.join(File.dirname(__FILE__), '../lib/warden/ldap')
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.include(Warden::Ldap::Helpers::RackHelpers)


### PR DESCRIPTION
This PR avoids RSpec output about now-defunct settings.